### PR TITLE
fix: more specific conditions for attachInterrupt() patches

### DIFF
--- a/src/ESP32RotaryEncoder.cpp
+++ b/src/ESP32RotaryEncoder.cpp
@@ -84,12 +84,14 @@ void RotaryEncoder::beginLoopTimer()
 
 void RotaryEncoder::attachInterrupts()
 {
-	#if defined( CORE_CORE_FUNCTIONALINTERRUPT_H_ ) && defined( __IO_PIN_REMAP_H__ ) && defined( attachInterrupt )
+	#if defined( BOARD_HAS_PIN_REMAP ) && ( ESP_ARDUINO_VERSION < ESP_ARDUINO_VERSION_VAL(3,0,0) )
 		/**
-		 * The io_pin_remap.h defines a `attachInterrupt()` macro that stomps on the function defined
-		 * in FunctionalInterrupt.h, which prevents attaching class methods to interrupts.  The macro just
-		 * folds-in a call to `digitalPinToGPIONumber()`, but FunctionalInterrupt.h does this too, so
-		 * we actually don't need the macro at all.
+		 * The io_pin_remap.h in Arduino-ESP32 cores of the 2.0.x family
+		 * (since 2.0.10) define an `attachInterrupt()` macro that folds-in
+		 * a call to `digitalPinToGPIONumber()`, but FunctionalInterrupt.cpp
+		 * does this too, so we actually don't need the macro at all.
+		 * Since 3.x the call inside the function was removed, so the wrapping
+		 * macro is useful again.
 		 */
 		#undef attachInterrupt
 	#endif

--- a/src/ESP32RotaryEncoder.h
+++ b/src/ESP32RotaryEncoder.h
@@ -20,23 +20,19 @@
 		#define ARDUINO_ISR_ATTR IRAM_ATTR
 	#endif
 
-	/**
-	 * BUG ALERT!
-	 * 
-	 * As of 28 September 2023
-	 * 
-	 * This will fail to compile.  You need to modify FunctionalInterrupt.h and change:
-	 *     void attachInterrupt(...)
-	 * to:
-	 *     void (attachInterrupt)(...)
-	 * 
-	 * See: https://forum.arduino.cc/t/easybutton-library-sample-code-does-not-work/1155696/3
-	 * 
-	 * Also see `attachInterrupts()` in ESP32RotaryEncoder.cpp for
-	 * the note about the `attachInterrupt()` macro
-	 */
-	#include <FunctionalInterrupt.h>
-
+	#if defined( ESP_ARDUINO_VERSION ) && ( ESP_ARDUINO_VERSION == ESP_ARDUINO_VERSION_VAL(2,0,10) )
+		/**
+		 * BUG ALERT!
+		 *
+		 * With Arduino-ESP32 core 2.0.10, the #include statement below
+		 * fails to compile due to a bug.
+		 * Also see `attachInterrupts()` in ESP32RotaryEncoder.cpp for
+		 * the note about the `attachInterrupt()` macro in 2.x cores.
+		 */
+		#error Please upgrade the Arduino-ESP32 core to use this library.
+	#else
+		#include <FunctionalInterrupt.h>
+	#endif
 #endif
 
 #define RE_DEFAULT_PIN  -1


### PR DESCRIPTION
Hello @MaffooClock and thanks for spotting this issue I was unaware of - we will fix this in the upcoming 3.x releases of the Arduino-ESP32 core with pin remapping. I have taken the liberty of adding a more precise version test so the `#undef` is done exactly where required.
Let me know if this is acceptable! :+1: 