### PR TITLE
Ensure mux is unlocked when !isEnabled

### DIFF
--- a/src/ESP32RotaryEncoder.cpp
+++ b/src/ESP32RotaryEncoder.cpp
@@ -238,8 +238,10 @@ bool RotaryEncoder::buttonPressed()
 {
   portENTER_CRITICAL( &mux );
 
-  if( !_isEnabled )
+  if( !_isEnabled ) {
+    portEXIT_CRITICAL( &mux );
     return false;
+  }
 
   if( buttonPressedFlag )
     ESP_LOGD( LOG_TAG, "Button pressed for %lu ms", buttonPressedDuration );
@@ -257,8 +259,10 @@ bool RotaryEncoder::encoderChanged()
 {
   portENTER_CRITICAL( &mux );
 
-  if( !_isEnabled )
+  if( !_isEnabled ) {
+    portEXIT_CRITICAL( &mux );
     return false;
+  }
 
   if( encoderChangedFlag )
     ESP_LOGD( LOG_TAG, "Knob turned; value: %ld", getEncoderValue() );


### PR DESCRIPTION
In `::buttonPressed()` and `::encoderChanged()`, the mux would not be unlocked if `!isEnabled`.