### PR TITLE
Avoid logging inside critical sections

### DIFF
--- a/src/ESP32RotaryEncoder.h
+++ b/src/ESP32RotaryEncoder.h
@@ -335,11 +335,13 @@ class RotaryEncoder {
     esp_timer_handle_t loopTimer;
 
     /**
-     * @brief Constrains the value set by `encoder_ISR()` and `setEncoderValue()`
-     * to be in the range set by `setBoundaries()`.
+     * @brief Constrains a value to be in the range set by `setBoundaries()`.
      *
+     * @param value The value to constrain
+     *
+     * @return The constrained value
      */
-    void constrainValue();
+    long constrainValue(long value);
 
     /**
      * @brief Attaches ISRs to encoder and button pins.


### PR DESCRIPTION
Move logging outside of critical sections, as holding a spinlock while doing a blocking operation (i.e. logging when enabled) will regularly cause a watchdog timeout.